### PR TITLE
Fix save-period inconsistant definition

### DIFF
--- a/train.py
+++ b/train.py
@@ -472,7 +472,7 @@ def parse_opt(known=False):
     parser.add_argument('--label-smoothing', type=float, default=0.0, help='Label smoothing epsilon')
     parser.add_argument('--patience', type=int, default=100, help='EarlyStopping patience (epochs without improvement)')
     parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')
-    parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
+    parser.add_argument('--save_period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
     parser.add_argument('--seed', type=int, default=0, help='Global training seed')
     parser.add_argument('--local_rank', type=int, default=-1, help='Automatic DDP Multi-GPU argument, do not modify')
 


### PR DESCRIPTION
Fixed inconsistency between variable name in train.py and argument in parser. The train.py code uses save_period as a variable, but the parser defined save-period. This has been corrected by changing save-period to save_period in the parser.

copilot:all
